### PR TITLE
🐛 fix: Remove yarn.lock file and fix yarn install command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,8 @@ WORKDIR /app
 COPY tsconfig*.json ./
 
 COPY package.json ./
-COPY yarn.lock ./
 
-RUN yarn install --frozen-lockfile
+RUN yarn install
 
 COPY . .
 
@@ -23,7 +22,6 @@ WORKDIR /app
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/package.json ./package.json
-COPY --from=builder /app/yarn.lock ./yarn.lock
 
 ENV VITE_API_URL=${VITE_API_URL}
 


### PR DESCRIPTION
## 🔍 이 PR로 해결하고자 하는 문제는 무엇인가요?
- Docker 빌드 과정에서 `yarn.lock` 파일이 존재하지 않아 발생하는 오류를 해결하고자 합니다.
- 빌드 중 패키지 설치 오류를 방지하기 위해 `yarn.lock` 파일을 제거하고, `yarn install` 명령어를 수정합니다.

## ✨ 이 PR로 주요하게 바뀐 점은 무엇인가요?
- Dockerfile에서 `yarn.lock` 파일 복사 부분을 제거했습니다.
- `yarn install` 명령어에서 `--frozen-lockfile` 옵션을 제거하여 정상적으로 패키지를 설치할 수 있도록 수정했습니다.

## 🔖 주요 변경 사항 외에 추가로 변경된 부분이 있나요?
없음

## 🙏🏻 리뷰어가 특히 봐주었으면 하는 부분은 무엇인가요?

> 개발 과정에서 다른 사람의 의견이 궁금하거나, 크로스 체크가 필요하다고 느낀 코드가 있으면 알려주세요.

-

## 🩺 이 PR로 테스트나 검증이 필요한 부분이 있나요?

> 테스트가 필요한 항목이나 테스트 코드가 추가되었다면 함께 작성해주세요.

-

## 📚 관련된 Issue나 Notion, 문서

> 이 PR이 해결하려는 문제와 관련된 Issue나 문서, Notion이 있다면 링크를 작성해주세요. Notion의 경우 [제목](링크) 형식으로 첨부해주세요.

-

## 🖥 작동하는 모습

> 스크린샷이나 녹화된 비디오, 또는 gif를 추가해서, 리뷰어가 변경점을 이해하는 데 도움이 되도록 해주세요.
