### PR TITLE
도커파일에서 패키지 관리자를 yarn에서 npm으로 변경

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,16 +4,15 @@ WORKDIR /app
 
 COPY tsconfig*.json ./
 
-COPY package.json ./
-
-RUN yarn install
+COPY package*.json ./
+RUN npm install
 
 COPY . .
 
 ARG VITE_API_URL
 ENV VITE_API_URL=${VITE_API_URL}
 
-RUN yarn build
+RUN npm run build || (echo "Build failed" && exit 1)
 
 FROM node:18-alpine
 
@@ -21,10 +20,10 @@ WORKDIR /app
 
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/dist ./dist
-COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/package.json ./
 
 ENV VITE_API_URL=${VITE_API_URL}
 
 EXPOSE 5173
 
-CMD ["yarn", "preview", "--host"]
+CMD ["npm", "run", "preview", "--", "--host"]


### PR DESCRIPTION
 - Change package manager command from yarn to npm to improve stability.

## 🔍 이 PR로 해결하고자 하는 문제는 무엇인가요?
- Docker 빌드 과정에서 발생하는 yarn.lock 관련 오류를 해결하고자 합니다.
- 현재 프로젝트는 npm을 사용하고 있으나, Dockerfile에서는 yarn 명령어를 사용하고 있어 빌드 실패가 발생하고 있습니다.

## ✨ 이 PR로 주요하게 바뀐 점은 무엇인가요?
- 패키지 매니저를 yarn에서 npm으로 변경
- package*.json 복사 명령어 수정으로 package-lock.json 포함
- preview 명령어를 npm 형식으로 수정

## 🔖 주요 변경 사항 외에 추가로 변경된 부분이 있나요?
없음

## 🙏🏻 리뷰어가 특히 봐주었으면 하는 부분은 무엇인가요?

> 개발 과정에서 다른 사람의 의견이 궁금하거나, 크로스 체크가 필요하다고 느낀 코드가 있으면 알려주세요.

-

## 🩺 이 PR로 테스트나 검증이 필요한 부분이 있나요?

> 테스트가 필요한 항목이나 테스트 코드가 추가되었다면 함께 작성해주세요.

-

## 📚 관련된 Issue나 Notion, 문서

> 이 PR이 해결하려는 문제와 관련된 Issue나 문서, Notion이 있다면 링크를 작성해주세요. Notion의 경우 [제목](링크) 형식으로 첨부해주세요.

-

## 🖥 작동하는 모습

> 스크린샷이나 녹화된 비디오, 또는 gif를 추가해서, 리뷰어가 변경점을 이해하는 데 도움이 되도록 해주세요.
