### PR TITLE
CI/CD 파일 및 Docker 파일 포트 설정 변경

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,9 +3,9 @@ name: Docker Build and Deploy
 on:
   pull_request:
     types: [closed]
-    branches: [main]  
+    branches: [main]
   workflow_dispatch:
-   
+
 jobs:
   build-and-deploy:
     name: Build, Push and Deploy
@@ -42,12 +42,11 @@ jobs:
       - name: Deploy to EC2
         uses: appleboy/ssh-action@master
         with:
-          host: ${{ secrets.EC2_IP }}  
+          host: ${{ secrets.EC2_IP }}
           username: ubuntu
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
-            docker stop esg-web-react || true
             cd ~/app
-            docker compose pull
-            docker compose up -d
+            docker-compose pull
+            docker-compose up -d
             docker image prune -f

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,6 @@ COPY --from=builder /app/package.json ./
 
 ENV VITE_API_URL=${VITE_API_URL}
 
-EXPOSE 5173
+EXPOSE 4173
 
 CMD ["npm", "run", "preview", "--", "--host"]


### PR DESCRIPTION
## 🔍 이 PR로 해결하고자 하는 문제는 무엇인가요?
이 작업을 통해 GitHub Actions의 EC2 배포 스크립트에서 발생하는 Docker Compose 명령어 오류 수정, 불필요한 Docker 명령어 제거 그리고 Dockerfile EXPOSE 4173 포트 설정으로 Vite preview 서버의 기본 포트와 일치 하는 작업을 수행.

## ✨ 이 PR로 주요하게 바뀐 점은 무엇인가요?
1. Dockerfile 기존 EXPOSE 5173 에서 4173으로 변경.
2. main.yml 파일에 배포 스크립트 오류를 수정

## 🔖 주요 변경 사항 외에 추가로 변경된 부분이 있나요?
없음

## 🙏🏻 리뷰어가 특히 봐주었으면 하는 부분은 무엇인가요?
없음

## 🩺 이 PR로 테스트나 검증이 필요한 부분이 있나요?
없음

## 📚 관련된 Issue나 Notion, 문서
없음

## 🖥 작동하는 모습

> 스크린샷이나 녹화된 비디오, 또는 gif를 추가해서, 리뷰어가 변경점을 이해하는 데 도움이 되도록 해주세요.
