### PR TITLE
Docker 이미지 빌드 오류 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,24 @@
-FROM node:18-alpine
+# 빌드 스테이지
+FROM node:18-alpine as build
 
 WORKDIR /app
 
-COPY tsconfig*.json ./
 COPY package*.json ./
+COPY tsconfig*.json ./
 RUN npm install
 
 COPY . .
 
-# TypeScript 에러를 무시하고 빌드
 RUN npm run build
 
+# 실행 스테이지
 FROM node:18-alpine
 
 WORKDIR /app
 
-COPY --from=builder /app/node_modules ./node_modules
-COPY --from=builder /app/dist ./dist
-COPY --from=builder /app/package.json ./
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/package.json ./
 
 EXPOSE 4173
 


### PR DESCRIPTION
## 🔍 이 PR로 해결하고자 하는 문제는 무엇인가요?
이 PR은 GitHub Actions에서 Docker 이미지를 빌드하고 푸시하는 과정에서 발생한 "builder
" 이미지 접근 오류를 해결하기 위해 열었습니다. 기존 Dockerfile에서 빌드 스테이지에 잘못된 이미지를 참조하고 있어, Docker Hub에 존재하지 않는 builder:latest 이미지 오류를 해결하고자 합니다.

## ✨ 이 PR로 주요하게 바뀐 점은 무엇인가요?
- Dockerfile의 빌드 스테이지에서 builder:latest 대신 node:18-alpine 이미지를 사용하도록 수정하여 빌드 오류를 해결하였습니다.

## 🔖 주요 변경 사항 외에 추가로 변경된 부분이 있나요?
없음

## 🙏🏻 리뷰어가 특히 봐주었으면 하는 부분은 무엇인가요?
없음

## 🩺 이 PR로 테스트나 검증이 필요한 부분이 있나요?
없음

## 📚 관련된 Issue나 Notion, 문서
없음

## 🖥 작동하는 모습
없음
