### PR TITLE
[FEAT] 멘토 카드  클릭 시 정보 보내기 + 오답 노트 저장

### DIFF
--- a/src/pages/Feedback.tsx
+++ b/src/pages/Feedback.tsx
@@ -8,6 +8,7 @@ import '../styles/feedback.css';
 import IncorrectNote from '../components/IncorrectNote';
 
 interface NoteData {
+  id: number;
   language: string;
   errorType: number;
   mdFile: string;
@@ -53,10 +54,10 @@ const Feedback: React.FC = () => {
       .then((data) => {
         if (data.info) {
           console.log(data.info);
-          dispatch(setUser(data.info)); // 유저 정보를 dispatch를 이용해서 리덕스 스토어에 저장
+          dispatch(setUser(data.info)); 
         } else {
           alert('로그인이 필요합니다.');
-          navigate('/login'); // 로그인 페이지로 이동
+          navigate('/login'); 
         }
       })
       .finally(() => setLoading(false));
@@ -72,7 +73,7 @@ const Feedback: React.FC = () => {
     return randomMessages[randomIndex];
   };
 
-  // POST 요청: 코드와 질문을 보내고 데이터 수신
+  // 코드와 질문을 보내고 데이터 수신
   const handleSubmitQuestion = async () => {
     const formattedCode = `\`\`\`\n${code}\n\`\`\``;
     try {
@@ -150,6 +151,11 @@ const Feedback: React.FC = () => {
     }
   };
 
+  const handleMentorClick = async (mentorId: number) => {
+    await handleSave();
+    navigate('/mentchat', { state: { mentorId } });
+  };
+
   return (
     <div className="feedback">
       <div className="container">
@@ -185,7 +191,7 @@ const Feedback: React.FC = () => {
               {mentors.map((mentor) => {
                 const languages = JSON.parse(mentor.useLanguage);
                 return (
-                  <div className='mentor-card' key={mentor.id}>
+                  <div className='mentor-card' key={mentor.id} onClick={() => handleMentorClick(mentor.id)}>
                     <img className='mentor-img' src={mentor.profilePicture} alt={mentor.name} />
                     <p>{mentor.name}</p>
                     <p>{languages.join(', ')}</p>


### PR DESCRIPTION
## 🔍 이 PR로 해결하고자 하는 문제는 무엇인가요?

 Feedback 페이지에서 멘토 카드를 클릭 시 해당 멘토의 정보를 보내고, 동시에 사용자가 받은 오답 노트를 저장하는 기능을 구현합니다.

## ✨ 이 PR로 주요하게 바뀐 점은 무엇인가요?

> 문제를 해결하면서 주요 변경 사항을 작성해주세요.
* 멘토 카드 클릭 시 선택된 멘토 정보를 서버로 전송
* 오답 노트를 저장하는 기능을 멘토 카드 클릭 이벤트에 통합
* 멘토 선택 및 오답 노트 저장 로직 간 연계성을 강화
* 사용자 경험 개선을 위한 마이너 UI/UX 조정

## 🔖 주요 변경 사항 외에 추가로 변경된 부분이 있나요?

> 없으면 "없음"이라고 작성해주세요.
* 없음

## 🙏🏻 리뷰어가 특히 봐주었으면 하는 부분은 무엇인가요?

> 개발 과정에서 다른 사람의 의견이 궁금하거나, 크로스 체크가 필요하다고 느낀 코드가 있으면 알려주세요.
* 멘토 정보와 오답 노트 저장 로직이 제대로 연계되었는지 확인 부탁드립니다.
* 클릭 이벤트가 중복 호출되지 않고 의도대로 작동하는지 검토 부탁드립니다.

## 🩺 이 PR로 테스트나 검증이 필요한 부분이 있나요?

> 테스트가 필요한 항목이나 테스트 코드가 추가되었다면 함께 작성해주세요.
* 멘토 정보 전송 및 오답 노트 저장 흐름 테스트 필요
* UI가 의도대로 작동하며 사용자에게 적합한 피드백을 제공하는지 확인 필요

## 📚 관련된 Issue나 Notion, 문서

> 이 PR이 해결하려는 문제와 관련된 Issue나 문서, Notion이 있다면 링크를 작성해주세요.
* 없음

## 🖥 작동하는 모습

> 스크린샷이나 녹화된 비디오, 또는 gif를 추가해서, 리뷰어가 변경점을 이해하는 데 도움이 되도록 해주세요.